### PR TITLE
IT Localization Hotfix

### DIFF
--- a/Localization/it-IT/Events.hjson
+++ b/Localization/it-IT/Events.hjson
@@ -5,11 +5,11 @@ Mods: {
 		    WaystoneActivation: "Waystone attivata!"
 
 			VillagerRespawned: {
-				Harpy: "{0} è appena nata!"
+				Harpy: "L'abitante arpia {0} è appena nata!"
 			}
 
 			VillagerLeft: {
-				Harpy: "{0} è partita in cerca di una nuova casa!"
+				Harpy: "L'abitante arpia {0} è partita in cerca di una nuova casa!"
 			}
 		}
 	

--- a/Localization/it-IT/Events.hjson
+++ b/Localization/it-IT/Events.hjson
@@ -5,11 +5,11 @@ Mods: {
 		    WaystoneActivation: "Waystone attivata!"
 
 			VillagerRespawned: {
-				Harpy: "{0} È nata un'abitante arpia!"
+				Harpy: "{0} è appena nata!"
 			}
 
 			VillagerLeft: {
-				Harpy: "{0} Un'abitante arpia è partita in cerca di una nuova casa!"
+				Harpy: "{0} è partita in cerca di una nuova casa!"
 			}
 		}
 	

--- a/Localization/it-IT/HarpyDialogue.hjson
+++ b/Localization/it-IT/HarpyDialogue.hjson
@@ -140,7 +140,7 @@ Mods: {
 					1: "Sei fortunato ad essere molto apprezzato qui nel villaggio. Altrimenti non faremmo sconti come questi!"
 					2: "Ehiii! Sono felice che tu sia potuto passare; hai qualche storia da raccontarci questa volta? Ci piacerebbe sentirle!"
 					3: "Se devo essere sincera, la prima volta che sei apparso nel villaggio, non eravamo sicure di cosa pensare di te. Non riceviamo mai visite dalla terra. Ma sai una cosa? Siamo contente che tu sia qui."
-					4: "Non trovi offensivo venir chiamato 'abitante della terra', vero? Lo diciamo da così tanto tempo! Oh, accidenti..."
+					4: "Non trovi offensivo essere chiamato 'abitante della terra', vero? Lo diciamo da così tanto tempo! Oh, accidenti..."
 					5: "Non so come si possa sopportare di andare sottoterra. L'aria dev'essere così viziata e secca... È molto meglio quassù in cielo!"
 				}
 

--- a/Localization/it-IT/HarpyDialogue.hjson
+++ b/Localization/it-IT/HarpyDialogue.hjson
@@ -53,7 +53,7 @@ Mods: {
 							1: "Sai, quando sei venuto qui per la prima volta, pensavo che fossi come tutti gli altri abitanti della terra, ma sono rimasta piacevolmente sorpresa che non è così. Ecco un piccolo sconto, da parte mia!"
 						}
 						Love: {
-							0: "Stai cercando qualcosa da comprare, abitante della terra? So che probabilmente potresti permetterti tutto a prezzo normale, ma non posso non farti uno sconto comunque."
+							0: "Stai cercando qualcosa da comprare, abitante della terra? So che probabilmente potresti permetterti tutto a prezzo standard, ma ti farò comunque uno sconto."
 							1: "Sai, abitante della terra, ti farò uno sconto. Immagino che te lo meriti per aver aiutato così tanto il villaggio, o quello che è. Dai! Compra qualcosa!"
 						}
 					}
@@ -140,7 +140,7 @@ Mods: {
 					1: "Sei fortunato ad essere molto apprezzato qui nel villaggio. Altrimenti non faremmo sconti come questi!"
 					2: "Ehiii! Sono felice che tu sia potuto passare; hai qualche storia da raccontarci questa volta? Ci piacerebbe sentirle!"
 					3: "Se devo essere sincera, la prima volta che sei apparso nel villaggio, non eravamo sicure di cosa pensare di te. Non riceviamo mai visite dalla terra. Ma sai una cosa? Siamo contente che tu sia qui."
-					4: "Non trovi offensivo che ti chiamiamo 'abitante della terra', vero? Lo diciamo da così tanto tempo! Oh, accidenti..."
+					4: "Non trovi offensivo venir chiamato 'abitante della terra', vero? Lo diciamo da così tanto tempo! Oh, accidenti..."
 					5: "Non so come si possa sopportare di andare sottoterra. L'aria dev'essere così viziata e secca... È molto meglio quassù in cielo!"
 				}
 

--- a/Localization/it-IT/MapInfo.hjson
+++ b/Localization/it-IT/MapInfo.hjson
@@ -3,7 +3,7 @@ Mods: {
 	
 		MapInfo: {
 			Shrines: {
-				Harpy: "Villaggio fluttuante delle arpie"
+				Harpy: "Villaggio delle arpie"
 			}
 			Waystones: {
 				Desert: "Waystone del deserto"

--- a/Localization/it-IT/Miscellaneous.hjson
+++ b/Localization/it-IT/Miscellaneous.hjson
@@ -2,7 +2,7 @@ Mods: {
 	LivingWorldMod: {
 	
 		VillagerType: {
-			Harpy: "Arpia"
+			Harpy: "Arpie"
 		}
 		
 	}

--- a/Localization/it-IT/TileItems.hjson
+++ b/Localization/it-IT/TileItems.hjson
@@ -18,7 +18,7 @@ Mods: {
 			//Interactables
 
 				//Shrines
-				HarpyShrineItem: "Santuario del villaggio fluttuante delle arpie"
+				HarpyShrineItem: "Santuario del villaggio delle arpie"
 
 			//Torches
 			StarTorchItem: "Torcia stellare"

--- a/Localization/it-IT/TileItems.hjson
+++ b/Localization/it-IT/TileItems.hjson
@@ -4,12 +4,12 @@ Mods: {
 		ItemName: {
 			//Building
 			SkywareBlockItem: "Blocco celeste"
-			StarshardCloudItem: "Nuvola di frammenti di stella"
-			StarshineBlockItem: "Blocco di bagliore stellare"
+			StarshardCloudItem: "Nuvola stellare"
+			StarshineBlockItem: "Blocco bagliore stellare"
 			SunslabBlockItem: "Lastra solare"
 
 			//Furniture
-			NimbusJarItem: "Nuvola in barattolo"
+			NimbusJarItem: "Nuvoletta in barattolo"
 			GravityTapestryItem: "Arazzo gravità"
 			SkywareAnvilItem: "Incudine celeste"
 			SkywareLoomItem: "Telaio celeste"

--- a/Localization/it-IT/TileItems.hjson
+++ b/Localization/it-IT/TileItems.hjson
@@ -21,7 +21,7 @@ Mods: {
 				HarpyShrineItem: "Santuario del villaggio delle arpie"
 
 			//Torches
-			StarTorchItem: "Torcia stellare"
+			StarTorchItem: "Torcia celeste"
 		}
 
 		ItemTooltip: {

--- a/Localization/it-IT/UI.hjson
+++ b/Localization/it-IT/UI.hjson
@@ -3,7 +3,7 @@ Mods: {
 	
 		UI: {
 			VillagerHousing: {
-				ButtonHoverText: "Alloggio"
+				ButtonHoverText: "Alloggio interspecie"
 				VillagerTypeLocked: "{0} Gli abitanti non possono essere trasferiti finché non sei di loro gradimento!"
 			}
 			Shrine: {

--- a/Localization/it-IT/UI.hjson
+++ b/Localization/it-IT/UI.hjson
@@ -4,7 +4,7 @@ Mods: {
 		UI: {
 			VillagerHousing: {
 				ButtonHoverText: "Alloggio interspecie"
-				VillagerTypeLocked: "{0} Gli abitanti non possono essere trasferiti finché non sei di loro gradimento!"
+				VillagerTypeLocked: "{0} non si trasferirà finché non sei di suo gradimento!"
 			}
 			Shrine: {
 				HarpyCountdown: "Uovo di arpia in:"

--- a/Localization/it-IT/UI.hjson
+++ b/Localization/it-IT/UI.hjson
@@ -7,7 +7,7 @@ Mods: {
 				VillagerTypeLocked: "{0} Gli abitanti non possono essere trasferiti finché non sei di loro gradimento!"
 			}
 			Shrine: {
-				HarpyCountdown: "Nuovo uovo di arpia in:"
+				HarpyCountdown: "Uovo di arpia in:"
 
 				AddText: "Aggiungi 1"
 				TakeText: "Prendi 1"

--- a/Localization/it-IT/UI.hjson
+++ b/Localization/it-IT/UI.hjson
@@ -4,7 +4,7 @@ Mods: {
 		UI: {
 			VillagerHousing: {
 				ButtonHoverText: "Alloggio interspecie"
-				VillagerTypeLocked: "{0} non si trasferirà finché non sei di suo gradimento!"
+				VillagerTypeLocked: "L'abitante arpia {0} non si trasferirà finché non sei di suo gradimento!"
 			}
 			Shrine: {
 				HarpyCountdown: "Uovo di arpia in:"
@@ -12,8 +12,8 @@ Mods: {
 				AddText: "Aggiungi 1"
 				TakeText: "Prendi 1"
 
-				DisableVillageRadius: "Nascondi la visualizzazione del raggio del villaggio"
-				EnableVillageRadius: "Mostra la visualizzazione del raggio del villaggio"
+				DisableVillageRadius: "Nascondi il raggio magico del villaggio"
+				EnableVillageRadius: "Visualizza il raggio magico del villaggio"
 
 				ForceShrineButtonText: "Forza sincronizzazione alloggio"
 			}


### PR DESCRIPTION
Made 2 npc dialogues more natural; updated harpy spawn event text (now it makes more sense instead of being, "harpy name" a villager harpy has hatched .in to. "harpy name" has hatched); changed some tiles name to be more readable with fewer letters (Nuvola di frammenti di stella .in to. Nuvola stellare); renamed some item to sync with vanilla items set (example: Torcia stellare .in to. Torcia celeste); other small fixes (example: Nuovo uovo di arpia in .in to. Uovo di arpia in and changed Arpia .in to. Arpie in the "Housing species menu?", it makes more sense in plural Arpie=Harpies).
Also changed the Housing exclusive button from the mod in to Interspecies housing (Alloggio .in to. Alloggio interspecie) this way is not the same as the vanilla one